### PR TITLE
add items to order

### DIFF
--- a/components/api/orderData.js
+++ b/components/api/orderData.js
@@ -69,8 +69,9 @@ const deleteOrder = (orderId) => {
 };
 
 // DELETE an item from an order
-const deleteOrderItem = (orderId, itemId) => {
-  const url = `${endpoint}/orders/${orderId}/items/${itemId}`;
+const deleteOrderItem = (orderId, orderItemId) => {
+  console.warn('Deleting item with orderId:', orderId, 'orderItemId:', orderItemId);
+  const url = `${endpoint}/orders/${orderId}/items/${orderItemId}`;
 
   return new Promise((resolve, reject) => {
     fetch(url, {
@@ -81,7 +82,7 @@ const deleteOrderItem = (orderId, itemId) => {
     })
       .then((response) => {
         if (!response.ok) {
-          throw new Error(`Failed to delete the item ${itemId} from order ${orderId}`);
+          throw new Error(`Failed to delete the order item ${orderItemId} from order ${orderId}`);
         }
         return response.text();
       })
@@ -140,6 +141,52 @@ const updateOrder = (orderId, updatedDetails) => {
   });
 };
 
+// ADD items to orders
+const addItemToOrder = (orderId, itemId) => {
+  const url = `${endpoint}/orders/${orderId}/items/${itemId}`;
+  const payload = { itemId };
+
+  return new Promise((resolve, reject) => {
+    fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Failed to add item to order');
+        }
+        return response.json();
+      })
+      .then((data) => resolve(data))
+      .catch((error) => reject(error));
+  });
+};
+
+// GET all items
+const getItems = () => {
+  const url = `${endpoint}/items`;
+
+  return new Promise((resolve, reject) => {
+    fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Failed to fetch items');
+        }
+        return response.json();
+      })
+      .then((data) => resolve(data))
+      .catch((error) => reject(error));
+  });
+};
+
 export {
-  getOrders, getOrderById, deleteOrder, deleteOrderItem, createNewOrder, updateOrder,
+  getOrders, getOrderById, deleteOrder, deleteOrderItem, createNewOrder, updateOrder, addItemToOrder, getItems,
 };

--- a/components/forms/AddItems.js
+++ b/components/forms/AddItems.js
@@ -1,0 +1,48 @@
+import React, { useState, useEffect } from 'react';
+import { Modal, Button, ListGroup } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import { getItems, addItemToOrder } from '../api/orderData';
+
+const ItemAddModal = ({ orderId }) => {
+  const [items, setItems] = useState([]);
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    getItems().then(setItems).catch(console.error);
+  }, []);
+
+  const handleAddItem = (itemId) => {
+    addItemToOrder(orderId, itemId)
+      .then((response) => {
+        console.warn('Item added:', response);
+      })
+      .catch(console.error);
+  };
+
+  return (
+    <>
+      <Button onClick={() => setShow(true)}>Add Items</Button>
+      <Modal show={show} onHide={() => setShow(false)} size="lg">
+        <Modal.Header closeButton>
+          <Modal.Title>Add Items to Order</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <ListGroup>
+            {items.map((item) => (
+              <ListGroup.Item key={item.itemId}>
+                {item.name} - ${item.price.toFixed(2)}
+                <Button variant="primary" size="sm" onClick={() => handleAddItem(item.itemId)}>Add</Button>
+              </ListGroup.Item>
+            ))}
+          </ListGroup>
+        </Modal.Body>
+      </Modal>
+    </>
+  );
+};
+
+ItemAddModal.propTypes = {
+  orderId: PropTypes.number.isRequired,
+};
+
+export default ItemAddModal;

--- a/pages/orders/[id].js
+++ b/pages/orders/[id].js
@@ -9,6 +9,7 @@ function OrderDetails() {
   const [error, setError] = useState(null);
   const router = useRouter();
   const { id } = router.query;
+  const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     if (router.isReady && id) {
@@ -22,7 +23,6 @@ function OrderDetails() {
     const isConfirmed = window.confirm('Are you sure you want to delete this order?');
     if (isConfirmed) {
       deleteOrder(id).then(() => {
-        alert('Order deleted successfully.');
         router.push('/orders');
       }).catch((err) => {
         console.error('Failed to delete order:', error);
@@ -31,14 +31,12 @@ function OrderDetails() {
     }
   };
 
-  const handleDeleteItem = (itemId) => {
-    const isConfirmed = window.confirm('Are you sure you want to delete this item?');
-    if (isConfirmed) {
-      deleteOrderItem(itemId).then(() => {
-        alert('Item deleted successfully.');
-        getOrderById(id).then(setOrder).catch(setError);
+  const handleDeleteItem = (orderId, orderItemId) => {
+    if (window.confirm('Are you sure you want to delete this item?')) {
+      deleteOrderItem(orderId, orderItemId).then(() => {
+        getOrderById(orderId).then(setOrder).catch(setError);
       }).catch((err) => {
-        console.error('Failed to delete item:', error);
+        console.error('Failed to delete item:', err);
         setError(err);
       });
     }
@@ -46,6 +44,15 @@ function OrderDetails() {
 
   const handleUpdateOrder = () => {
     router.push(`/orders/edit/${id}`);
+  };
+
+  const handleAddItem = () => {
+    console.warn('handleAddItem called');
+    setShowModal(true);
+  };
+
+  const onCloseModal = () => {
+    setShowModal(false);
   };
 
   if (error) {
@@ -56,17 +63,23 @@ function OrderDetails() {
     return <div>Loading...</div>;
   }
 
+  console.warn('showModal value:', showModal);
+
   return (
     <div id="order-detailspage"><br />
       <h1>{`${order.customerName}'s Order`}</h1><br />
       <div id="order-details">
-        {/* render over order.items and render an OrderDetailsCard for each */}
         <OrderDetailsCard
           order={order}
           onDeleteOrder={handleDeleteOrder}
           onDeleteItem={handleDeleteItem}
           onUpdate={handleUpdateOrder}
+          onAddItem={handleAddItem}
+          onCloseModal={onCloseModal}
+          setShowModal={setShowModal}
+          setOrder={setOrder}
         />
+
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
User can now add items to an order.
- Added the API call for adding items to orders, and getting all items
- Added setOrder as a prop to re-render the page upon changes to the order detail card
- Added functions for getting items, updating details, & adding the items
- Created the pop up modal for adding items
- Fixed a bug with delete items not working (not properly calling the orderItemId, was just calling itemId at first, and adding orderId to the delete function as well)

## Related Issue
#8 #6 

## Motivation and Context
This is necessary to ensure proper functionality for deleting items & the MVP requirement of adding items to orders.

## How Can This Be Tested?
By opening up swagger and the front end local host.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
